### PR TITLE
Eliminate resource leaks, and a string copy

### DIFF
--- a/app/src/main/jni/pybridge.c
+++ b/app/src/main/jni/pybridge.c
@@ -111,6 +111,11 @@ JNIEXPORT jint JNICALL Java_com_jventura_pybridge_PyBridge_start
 
     // Bootstrap
     PyRun_SimpleString("import bootstrap");
+
+    // Cleanup
+    (*env)->ReleaseStringUTFChars(env, path, pypath);
+    PyMem_RawFree(wchar_paths);
+
     return 0;
 }
 
@@ -153,8 +158,7 @@ JNIEXPORT jstring JNICALL Java_com_jventura_pybridge_PyBridge_call
 
     // We must copy the characters as we will lose the reference
     // to char *myResultChar when we DECREF PyObject* myResult
-    char *res = malloc(sizeof(char) * strlen(myResultChar) + 1);
-    strcpy(res, myResultChar);
+    jstring result = (*env)->NewStringUTF(env, myResultChar);
 
     // Cleanup
     (*env)->ReleaseStringUTFChars(env, payload, payload_utf);
@@ -163,8 +167,7 @@ JNIEXPORT jstring JNICALL Java_com_jventura_pybridge_PyBridge_call
     Py_DECREF(myFunction);
     Py_DECREF(args);
     Py_DECREF(myResult);
+    // myResultChar is stored inside myResult, so doesn't need freeing
 
-    // We do not need to free res as the JVM will eventually GC the jstring
-    jstring result = (*env)->NewStringUTF(env, res);
     return result;
 }


### PR DESCRIPTION
Came across these resource leaks while experimenting with Python on Android, and figured I should contribute.  The leaks in init aren't a big deal since it runs once, but probably best to clean up properly when acting as en example.  The original comment about the `res` buffer allocated with malloc was incorrect: NewStringUTF copies its input, without taking ownership.  This version avoids an extra copy as well as that memory allocation.

Thanks so much for this sample.  It greatly eased my attempts to try out Python on Android, once I discovered it after having trouble building Kivy.  I've done some additional experimentation with error handling and performance timing in my fork, which you're welcome examine in my branch [here](https://github.com/dropbox/pybridge/tree/epdhackweek17/pybridge-test).  It's not cleaned up enough for publication, though, so I'm not going to try to push it.